### PR TITLE
Incorrect service name no longer causes error on boot

### DIFF
--- a/services/exampleCustomAction/config.json
+++ b/services/exampleCustomAction/config.json
@@ -1,6 +1,6 @@
 {
 	"services": {
-		"exampleCustomActionsService": {
+		"exampleCustomActionService": {
 			"useWindow": true,
 			"active": true,
 			"name": "exampleCustomActionService",


### PR DESCRIPTION
Test: 

Include the sample config
ExampleCustomAction service will not cause boot error