### PR TITLE
toaster is now responsive and can be resized via config

### DIFF
--- a/components/notification-toaster/App.tsx
+++ b/components/notification-toaster/App.tsx
@@ -101,7 +101,7 @@ function App(): React.ReactElement {
 
 	return (
 		<>
-			<div onMouseDown={onmousedown} onMouseUp={onmouseup}>
+			<div onMouseDown={onmousedown} onMouseUp={onmouseup} className="drag-container">
 				<DragHandleIcon id="drag-area" className="drag-area" />
 			</div>
 			{activeNotifications(notifications).length > 0 && (

--- a/components/notification-toaster/config.json
+++ b/components/notification-toaster/config.json
@@ -7,8 +7,8 @@
 				"forceOntoMonitor": true,
 				"bottom": 0,
 				"left": "50%",
-				"height": 32,
-				"width": 120,
+				"height": 45,
+				"width": 150,
 				"position": "available",
 				"options": {
 					"resizable": false,

--- a/components/notification-toaster/notification-toaster.css
+++ b/components/notification-toaster/notification-toaster.css
@@ -13,7 +13,7 @@
 }
 
 body {
-	margin: 0px;
+	margin: 0;
 }
 #notifications-toaster {
 	display: flex;
@@ -23,16 +23,21 @@ body {
 	padding: 0;
 	overflow: hidden;
 	width: 100vw;
-	height: 32px;
+	height: 100vh;
 	background: #22262f;
 	border-radius: 13px;
 }
 
+.drag-container {
+	padding: 30vh 0 0;
+	height: 100%;
+	align-items: center;
+}
+
 .drag-area {
-	cursor: pointer;
-	width: 15px;
-	height: 17px;
-	padding: 3px 0;
+	cursor: grab;
+	width: auto;
+	height: 65%;
 }
 
 .drag-box {
@@ -48,6 +53,8 @@ body {
 
 .toaster-icons {
 	cursor: pointer;
+	height: 70%;
+	width: auto;
 }
 .toaster-icons:hover {
 	background-color: var(--notification-primary-color);

--- a/components/shared/components/icons/DragHandleIcon.tsx
+++ b/components/shared/components/icons/DragHandleIcon.tsx
@@ -5,8 +5,8 @@ export default function DragHandleIcon(props: SVGProps) {
 	return (
 		<SVGBase
 			{...props}
-			width="8"
-			height="15"
+			width="5"
+			height="11"
 			viewBox="0 0 5 11"
 			opacity="0.408315"
 			fillRule="evenodd"


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/106/cards/26492/details/
Notifications - Allow developers to resize/rescale the Toaster via config


- [ ] Run this branch
- [ ] Change the toaster size in the config
- [ ] toaster and icons should scale to fit the size