### PR TITLE
Added alternative behaviour when transparency is false

### DIFF
--- a/components/notification-toaster/App.tsx
+++ b/components/notification-toaster/App.tsx
@@ -11,7 +11,9 @@ const { useEffect, useState } = React;
 
 function App(): React.ReactElement {
 	const [toasterMonitorPosition, settoasterMonitorPosition] = useState("0");
-	const { notifications, activeNotifications } = useNotifications({ config: { notificationsHistory: true } });
+	const { notifications, activeNotifications, getNotificationConfig, setOpaqueClassName } = useNotifications({
+		config: { notificationsHistory: true }
+	});
 	const pubSubTopic = "notification-ui";
 	const [notificationSubscribeMessage, notificationsPublish] = usePubSub(pubSubTopic);
 	const [count, setCount] = useState(activeNotifications(notifications).length);
@@ -19,6 +21,8 @@ function App(): React.ReactElement {
 	useEffect(() => {
 		setCount(activeNotifications(notifications).length);
 	}, [notifications]);
+
+	const config = getNotificationConfig();
 
 	useEffect(() => {
 		const hotkey = _get(FSBL.Clients.WindowClient.getSpawnData(), "notifications.hotkey", null);
@@ -28,6 +32,8 @@ function App(): React.ReactElement {
 				FSBL.Clients.WindowClient.showAtMousePosition();
 			});
 		}
+		setOpaqueClassName(!config.isTransparent);
+
 		return () => {
 			// cleanup;
 		};

--- a/components/notification-toaster/notification-toaster.css
+++ b/components/notification-toaster/notification-toaster.css
@@ -15,6 +15,16 @@
 body {
 	margin: 0;
 }
+
+body.opaque {
+	background-color: var(--notification-background-color);
+	margin: 0;
+}
+
+.opaque #notifications-toaster {
+	border-radius: 0;
+}
+
 #notifications-toaster {
 	display: flex;
 	align-items: center;

--- a/components/notification-toasts/App.tsx
+++ b/components/notification-toasts/App.tsx
@@ -21,13 +21,14 @@ function App(): React.ReactElement {
 		removeNotification,
 		getNotificationConfig,
 		activeNotifications,
-		notificationIsActive
+		notificationIsActive,
+		setOpaqueClassName
 	} = useNotifications();
 
 	const pubSubTopic = "notification-ui";
 	const [notificationSubscribeMessage, notificationsPublish] = usePubSub(pubSubTopic);
 
-	const config = getNotificationConfig("notification-toasts");
+	const config = getNotificationConfig();
 
 	const windowShowParams: SpawnParams = _get(config, "config.position", {
 		bottom: 0,
@@ -67,6 +68,10 @@ function App(): React.ReactElement {
 	};
 
 	useEffect(() => {
+		setOpaqueClassName(!config.isTransparent);
+	}, []);
+
+	useEffect(() => {
 		if (
 			currentMonitor !== notificationSubscribeMessage.toasterMonitorPosition &&
 			!activeNotifications(notifications).length
@@ -78,22 +83,55 @@ function App(): React.ReactElement {
 
 		const rect = document.getElementById("toasts-drawer").getBoundingClientRect();
 		if (notifications.length === 0) {
-			const roundedRect = {
-				x: Math.round(rect.x),
-				y: Math.round(rect.y),
-				width: 1,
-				height: 1
-			};
-			FSBL.Clients.WindowClient.setShape([roundedRect]);
+			if (config.isTransparent) {
+				const roundedRect = {
+					x: Math.round(rect.x),
+					y: Math.round(rect.y),
+					width: 1,
+					height: 1
+				};
+				FSBL.Clients.WindowClient.setShape([roundedRect]);
+			} else {
+				finsembleWindow.hide();
+			}
 		} else {
 			finsembleWindow.bringToFront();
-			const roundedRect = {
-				x: Math.round(rect.x),
-				y: Math.round(rect.y),
-				width: Math.round(rect.width),
-				height: Math.round(rect.height)
-			};
-			FSBL.Clients.WindowClient.setShape([roundedRect]);
+			if (config.isTransparent) {
+				const roundedRect = {
+					x: Math.round(rect.x),
+					y: Math.round(rect.y),
+					width: Math.round(rect.width),
+					height: Math.round(rect.height)
+				};
+				FSBL.Clients.WindowClient.setShape([roundedRect]);
+			} else {
+				finsembleWindow.show({}, async () => {
+					const { err, data } = (await FSBL.Clients.LauncherClient.getMonitorInfo({ monitor: "mine" })) as any;
+
+					if (err) {
+						console.error(err);
+						return;
+					}
+
+					const bounds = (await finsembleWindow.getBounds({})) as any;
+					const width = bounds.data.right - bounds.data.left;
+					const height = Math.round(rect.height) + 6;
+
+					finsembleWindow.setBounds(
+						{
+							top: data["availableRect"]["bottom"] - height,
+							left: data["availableRect"]["right"] - width,
+							height: height,
+							width: width
+						},
+						(err: any) => {
+							if (err) {
+								console.error(err);
+							}
+						}
+					);
+				});
+			}
 		}
 	}, [notifications, notificationSubscribeMessage]);
 

--- a/components/notification-toasts/config.json
+++ b/components/notification-toasts/config.json
@@ -7,7 +7,7 @@
 				"forceOntoMonitor": true,
 				"bottom": 0,
 				"right": 0,
-				"width": 370,
+				"width": 364,
 				"height": "100%",
 				"minHeight": 30,
 				"position": "available",

--- a/components/notification-toasts/notification-toasts.css
+++ b/components/notification-toasts/notification-toasts.css
@@ -12,6 +12,10 @@
 	--notification-font-color: var(--notification-contrast-color);
 }
 
+.opaque body {
+	background-color: black;
+}
+
 body {
 	margin: 0;
 	position: absolute;
@@ -24,6 +28,11 @@ body {
 	flex-direction: column-reverse;
 	align-items: flex-end;
 }
+
+.opaque .notification {
+	margin-right: 8px;
+}
+
 .notification {
 	margin-left: 0;
 	margin-bottom: 6px;
@@ -63,6 +72,8 @@ img#close-icon:hover {
 }
 .detail-area_time {
 	font-size: 12px;
+	min-width: 137px;
+	text-align: right;
 }
 .detail-area_type {
 	font-weight: 60;

--- a/components/shared/components/ConditionalWrapper.tsx
+++ b/components/shared/components/ConditionalWrapper.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+interface Props {
+	condition: boolean;
+	wrapper: (children: React.PropsWithChildren<any>) => void;
+	children?: React.PropsWithChildren<any>;
+}
+
+export default function ConditionalWrapper(props: Props) {
+	const { condition, wrapper, children } = props;
+
+	return <>{condition ? wrapper(children) : children}</>;
+}

--- a/types/Notification-definitions/NotificationConfig.d.ts
+++ b/types/Notification-definitions/NotificationConfig.d.ts
@@ -11,6 +11,7 @@ export interface NotificationsConfig {
 		animateIn: string;
 		animateOut: string;
 	};
+	isTransparent?: boolean;
 	notificationsHistory?: boolean;
 }
 


### PR DESCRIPTION
Added alternative behaviour for the UI when Transparency is false

Card: https://cosaic.kanbanize.com/ctrl_board/106/cards/27911/details/

Testing: 

- [ ]  Set the transparency for config for the Toaster, Toasts and Drawer components to false.
- [ ] The components hide() and show() rather than animate using setShape().
