### PR TITLE
Fix errors due to Finsemble 5.0 package paths.

### DIFF
--- a/components/notification-toaster/App.tsx
+++ b/components/notification-toaster/App.tsx
@@ -4,7 +4,7 @@ import DragHandleIcon from "../shared/components/icons/DragHandleIcon";
 import NotificationIcon from "../shared/components/icons/NotificationIcon";
 import CenterIcon from "../shared/components/icons/CenterIcon";
 import SettingsIcon from "../shared/components/icons/settings";
-import _get = require("lodash/get");
+const _get = require("lodash/get");
 import { usePubSub } from "../shared/hooks/finsemble-hooks";
 
 const { useEffect, useState } = React;

--- a/components/notification-toasts/App.tsx
+++ b/components/notification-toasts/App.tsx
@@ -4,7 +4,7 @@ import Notification from "../shared/components/Notification";
 import useNotifications from "../shared/hooks/useNotifications";
 import INotification from "../../types/Notification-definitions/INotification";
 import Animate from "../shared/components/Animate";
-import { SpawnParams } from "@chartiq/finsemble/dist/types/services/window/Launcher/launcher";
+import { SpawnParams } from "services/window/Launcher/launcher";
 import { usePubSub } from "../shared/hooks/finsemble-hooks";
 import { useState } from "react";
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/components/notification-toasts/components/Drawer.tsx
+++ b/components/notification-toasts/components/Drawer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import INotification from "../../../types/Notification-definitions/INotification";
-import { SpawnParams } from "@chartiq/finsemble/dist/types/services/window/Launcher/launcher";
+import { SpawnParams } from "services/window/Launcher/launcher";
 
 interface Props {
 	children: React.PropsWithChildren<any>;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@babel/register": "^7.8.3",
-		"@chartiq/finsemble": "^4.3.0",
+		"@finsemble/finsemble-core": "^5.0.1",
 		"@testing-library/react": "^9.4.0",
 		"@types/chai": "^4.2.7",
 		"@types/lodash": "^4.14.149",

--- a/sample.config.json
+++ b/sample.config.json
@@ -1,10 +1,8 @@
 {
-	"wpfNotificationExampleBase": "C:/Users/admin/Documents/code/finsemble-seed/src",
 	"importConfig": [
 		"$applicationRoot/components/finsemble-notifications/components/notify/config.json",
 		"$applicationRoot/components/finsemble-notifications/components/QANotificationTest/config.json",
 		"$applicationRoot/components/finsemble-notifications/components/subscriber/config.json",
-		"$applicationRoot/components/finsemble-notifications/services/exampleCustomAction/config.json",
-		"$applicationRoot/components/finsemble-notifications/dot-net-examples/NotifyComponent/config.json"
+		"$applicationRoot/components/finsemble-notifications/services/exampleCustomAction/config.json"
 	]
 }

--- a/services/exampleCustomAction/exampleCustomActionService.ts
+++ b/services/exampleCustomAction/exampleCustomActionService.ts
@@ -1,7 +1,7 @@
 import NotificationClient from "../notification/notificationClient";
 
 // eslint-disable-next-line
-const Finsemble = require("@chartiq/finsemble");
+const Finsemble = require("@finsemble/finsemble-core");
 
 Finsemble.Clients.Logger.start();
 Finsemble.Clients.Logger.log("exampleCustomActionService Service starting up");

--- a/services/helpers/RouterWrapper.ts
+++ b/services/helpers/RouterWrapper.ts
@@ -1,7 +1,8 @@
-import { IRouterClient } from "@chartiq/finsemble/dist/types/clients/IRouterClient";
-import { ILogger } from "@chartiq/finsemble/dist/types/clients/ILogger";
+import { ILogger } from "clients/ILogger";
+import { IRouterClient } from "clients/IRouterClient";
 
-const { RouterClient, Logger } = require("@chartiq/finsemble").Clients;
+const { RouterClient, Logger } = require("@finsemble/finsemble-core").Clients;
+
 const FSBL = window.FSBL;
 
 /**

--- a/services/notification/NotificationService.ts
+++ b/services/notification/NotificationService.ts
@@ -18,7 +18,7 @@ import StorageHelper, { STORAGE_KEY_NOTIFICATION_PREFIX } from "../helpers/Stora
 
 // TODO: Add Ticket to allow importing Finsemble
 // eslint-disable-next-line
-const Finsemble = require("@chartiq/finsemble");
+const Finsemble = require("@finsemble/finsemble-core");
 
 Finsemble.Clients.Logger.start();
 Finsemble.Clients.Logger.log("notification Service starting up");

--- a/services/notification/notificationClient.ts
+++ b/services/notification/notificationClient.ts
@@ -10,10 +10,10 @@ import OnSubscriptionSuccessCallback, {
 	OnNotificationCallback,
 	OnSubscriptionFaultCallback
 } from "../../types/Notification-definitions/Callbacks";
-import { ILogger } from "@chartiq/finsemble/dist/types/clients/ILogger";
-import { IRouterClient } from "@chartiq/finsemble/dist/types/clients/IRouterClient";
+import { ILogger } from "clients/ILogger";
+import { IRouterClient } from "clients/IRouterClient";
 
-const { Logger } = require("@chartiq/finsemble").Clients;
+const { Logger } = require("@finsemble/finsemble-core").Clients;
 const FSBL = window.FSBL;
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"preserveConstEnums": true,
 		"sourceMap": true,
 		"jsx": "react",
-		"types": ["@types/mocha", "@types/node", "@types/chai", "@testing-library/react", "@chartiq/finsemble"]
+		"types": ["@types/mocha", "@types/node", "@types/chai", "@testing-library/react", "@finsemble/finsemble-core"]
 	},
 	"include": ["**/*"],
 	"exclude": ["./node_modules/**", "**/*.spec.ts", "./types", "./docs", "./tests", "./preloads", "./services"]

--- a/types/Notification-definitions/NotificationConfig.d.ts
+++ b/types/Notification-definitions/NotificationConfig.d.ts
@@ -1,4 +1,4 @@
-import { SpawnParams } from "@chartiq/finsemble/dist/types/services/window/Launcher/launcher";
+import { SpawnParams } from "services/window/Launcher/launcher";
 
 export interface NotificationsConfig {
 	filter?: {


### PR DESCRIPTION
When using with Finsemble 5.0 the paths have changed. Updting the packages to work when imported into the seed Project.