### PR TITLE
Don't attach images to DOM if logos are missing

### DIFF
--- a/components/notification-center/components/NotificationDetailPanel.tsx
+++ b/components/notification-center/components/NotificationDetailPanel.tsx
@@ -80,7 +80,7 @@ const HeaderArea = (props: NotificationHeaderProps) => {
 	return (
 		<div className="card_header">
 			<div className="notification_logo">
-				<img src={headerLogo} />
+				{headerLogo && <img src={headerLogo} />}
 				<div>{headerText}</div>
 			</div>
 			<br />
@@ -98,7 +98,7 @@ const ContentArea = (props: NotificationContentProps) => {
 		<div className="details">
 			<h4 className="title">{title}</h4>
 			<div className="notification_content">
-				<img src={contentLogo} />
+				{contentLogo && <img src={contentLogo} />}
 				<div>{details}</div>
 			</div>
 			<div className="meta-details">

--- a/components/shared/components/Notification.tsx
+++ b/components/shared/components/Notification.tsx
@@ -41,9 +41,11 @@ const HeaderArea = (props: Props) => {
 
 	return (
 		<div className="detail-area">
-			<div>
-				<img src={notification.headerLogo} />
-			</div>
+			{notification.headerLogo && (
+				<div>
+					<img src={notification.headerLogo} />
+				</div>
+			)}
 			<div className="detail-area_type">{notification.headerText}</div>
 			<div className="detail-area_time">{time} ago</div>
 			{closeButton && <CloseIcon className="close-icon" onClick={() => closeAction && closeAction()} />}
@@ -54,11 +56,15 @@ const HeaderArea = (props: Props) => {
 const ContentArea = (props: Props) => {
 	const { notification } = props;
 
+	console.log("notification: ", notification);
+
 	return (
 		<div className="content-area">
-			<div>
-				<img src={notification.contentLogo} />
-			</div>
+			{notification.contentLogo && (
+				<div>
+					<img src={notification.contentLogo} />
+				</div>
+			)}
 			<div>
 				<h2>{notification.title}</h2>
 				<p>{notification.details}</p>

--- a/components/shared/components/Notification.tsx
+++ b/components/shared/components/Notification.tsx
@@ -56,7 +56,6 @@ const HeaderArea = (props: Props) => {
 const ContentArea = (props: Props) => {
 	const { notification } = props;
 
-	console.log("notification: ", notification);
 
 	return (
 		<div className="content-area">


### PR DESCRIPTION
- Adds React changes to avoid attaching <img> to DOM when `contentLogo` or `headerLogo` are undefined for a notification