### PR TITLE
31494 Make notification UI components system components

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Add the notification config your finsemble seed config file: `./finsemble-seed/c
 ]
 ```
 
-This line will add the Notification Center, Toasts, toaster and drawer to your project.
+This line will add the Notification Center, Toasts, toaster and drawer to your project. Please note that each of the individual component configs set `component.category = "system` (as do other Finsemble system UI components), which ensures that Finsemble does not drop them from the configuration if a component configuration is imported dynamically.
+
 
 ### Selective Finsemble Config
 

--- a/components/notification-center/config.json
+++ b/components/notification-center/config.json
@@ -24,7 +24,8 @@
 			"component": {
 				"preload": false,
 				"spawnOnStartup": true,
-				"singleton": true
+				"singleton": true,
+				"category": "system"
 			},
 			"foreign": {
 				"services": {

--- a/components/notification-drawer/config.json
+++ b/components/notification-drawer/config.json
@@ -28,7 +28,8 @@
 			"component": {
 				"preload": false,
 				"spawnOnStartup": true,
-				"singleton": true
+				"singleton": true,
+				"category": "system"
 			},
 			"foreign": {
 				"components": {

--- a/components/notification-overflow-menu/config.json
+++ b/components/notification-overflow-menu/config.json
@@ -24,7 +24,8 @@
 			"component": {
 				"preload": false,
 				"spawnOnStartup": true,
-				"singleton": true
+				"singleton": true,
+				"category": "system"
 			},
 			"foreign": {
 				"services": {

--- a/components/notification-toaster/config.json
+++ b/components/notification-toaster/config.json
@@ -27,7 +27,8 @@
 			"component": {
 				"preload": false,
 				"spawnOnStartup": true,
-				"singleton": true
+				"singleton": true,
+				"category": "system"
 			},
 			"foreign": {
 				"services": {

--- a/components/notification-toasts/config.json
+++ b/components/notification-toasts/config.json
@@ -41,7 +41,8 @@
 			"component": {
 				"preload": false,
 				"spawnOnStartup": true,
-				"singleton": true
+				"singleton": true,
+				"category": "system"
 			},
 			"foreign": {
 				"components": {

--- a/components/notify/config.json
+++ b/components/notify/config.json
@@ -14,7 +14,8 @@
 			},
 			"component": {
 				"inject": false,
-				"spawnOnStartup": false
+				"spawnOnStartup": false,
+				"category": "system"
 			},
 			"foreign": {
 				"services": {

--- a/components/subscriber/config.json
+++ b/components/subscriber/config.json
@@ -14,7 +14,8 @@
 			},
 			"component": {
 				"inject": false,
-				"spawnOnStartup": false
+				"spawnOnStartup": false,
+				"category": "system"
 			},
 			"foreign": {
 				"services": {


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/31494/details/

**Description:**
The notifications UI components do not have `component.category = "system"` set on them so they are wiped out by dynamic config when importing other components. As system UI components they should not be.

**Expected Result:**
Notifications components imported via config file inportConfig statements should not be wiped out by later dynamic config imports.

**Steps To Reproduce:**
- Apply the dynamic config recipe to the seed project (can just check out https://github.com/ChartIQ/finsemble-seed/tree/recipes/dynamic-config-example-5.0)
- Install the notifications add on into the seed via the watch script
- Start finsemble and select a user at the prompt
- Observe that the notification UI components are not present